### PR TITLE
[FEAT] 테스트 퀴즈 타이머 구현 

### DIFF
--- a/Gotchai/Feature/Main/Sources/TuringTest/Quiz/QuizView.swift
+++ b/Gotchai/Feature/Main/Sources/TuringTest/Quiz/QuizView.swift
@@ -15,7 +15,9 @@ struct QuizView: View {
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
             VStack(alignment: .leading) {
-                timerBar(seconds: 2)
+                
+                let progress = CGFloat(viewStore.secondsElapsed) / CGFloat(viewStore.totalSeconds)
+                TimerBar(progress: progress)
                     .padding(.top, 4)
                     .padding(.bottom, 28)
                 
@@ -74,15 +76,17 @@ struct QuizView: View {
     }
     
     @ViewBuilder
-    private func timerBar(seconds: Int) -> some View {
-        ZStack(alignment: .leading) {
-            RoundedRectangle(cornerRadius: 3)
-                .fill(Color(.gray_white).opacity(0.2))
-                .frame(maxWidth: .infinity)
-            GeometryReader { geometry in
+    private func TimerBar(progress: CGFloat) -> some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Color(.gray_white).opacity(0.2))
+                    .frame(maxWidth: .infinity)
+            
                 RoundedRectangle(cornerRadius: 3)
                     .fill(Color(.primary_400))
-                    .frame(width: geometry.size.width * CGFloat(seconds/10))
+                    .frame(width: geometry.size.width * progress)
+                    .animation(.linear(duration: 1), value: progress)
             }
         }
         .frame(height: 5)

--- a/Gotchai/Feature/Main/Sources/TuringTest/Quiz/QuizView.swift
+++ b/Gotchai/Feature/Main/Sources/TuringTest/Quiz/QuizView.swift
@@ -44,6 +44,7 @@ struct QuizView: View {
                         } label: {
                             AnswerCard(idx: index, text: item, state: viewStore.answerCardState[index])
                         }
+                        .allowsHitTesting(!viewStore.state.isSelectedAnswer)    // 답 선택하면 터치 막기
                     }
                 }
                 .padding(.top, 76)


### PR DESCRIPTION
<!-- PR 제목은 아래를 따라주세요!
	- [FEAT]: xxx화면 yy기능 개발
	- [FIX]: zzz버그 수정
	- [RELEASE]: alpha version 배포 
 -->

##  관련 이슈
- #18 

## 작업 내용 및 특이 사항
- 퀴즈 화면 진입 시 타이머 시작 (10초) -> progress bar 뷰 
- 답 선택 시 모든 액션 stop (다른 답 선택, 타이머)

## 참고

## 실행 화면
<!--
화면의 스크린샷 또는 영상을 같이 첨부해주세요.
적절한 사이즈로 첨부하는 코드 👇
<img width="300" alt="" src="URL">
-->

[시간 초과]

https://github.com/user-attachments/assets/d01f48b3-cb1a-47d0-a0ea-b31c8fda4aa4


[답 선택 시]

https://github.com/user-attachments/assets/2b8b11dd-e952-4c57-a213-51d2e273a2b0




## 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?
